### PR TITLE
cmake: add byproducts and dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ enable_testing()
 add_custom_target(cli ALL
   go build -o ${CMAKE_BINARY_DIR}/cli -ldflags "-X main.version=${PROJECT_VERSION}"
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/cli
+  BYPRODUCTS cli
 )
 
 #
@@ -33,10 +34,14 @@ add_custom_target(images ALL
 add_custom_target(delegatio-agent ALL
   go build -o ${CMAKE_BINARY_DIR}/delegatio-agent
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/cmd
+  BYPRODUCTS delegatio-agent
 )
+
+add_dependencies(cpy delegatio-agent)
 
 
 add_custom_target(ssh ALL
   go build -o ${CMAKE_BINARY_DIR}/ssh
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/ssh
+  BYPRODUCTS ssh
 )


### PR DESCRIPTION
The dependency is needed to avoid:
```
euler@work:~/projects/delegatio/build$ cmake ..
-- The C compiler identification is GNU 11.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/euler/projects/delegatio/build
euler@work:~/projects/delegatio/build$ make
Built target cli
cp: cannot stat '/home/euler/projects/delegatio/build/delegatio-agent': No such file or directory
make[2]: *** [CMakeFiles/cpy.dir/build.make:70: CMakeFiles/cpy] Error 1
make[1]: *** [CMakeFiles/Makefile2:117: CMakeFiles/cpy.dir/all] Error 2
make: *** [Makefile:101: all] Error 2
```